### PR TITLE
changed constant definition for new line (NL)

### DIFF
--- a/dockerveth.sh
+++ b/dockerveth.sh
@@ -20,8 +20,7 @@
 # DECLARE CONSTANTS #
 #####################
 
-NL='
-'
+NL=$'\n'
 
 ####################
 # DEFINE FUNCTIONS #


### PR DESCRIPTION
when copying between windows and unix new line may be \r\n value and therefore displays
"valid_lft forever preferred_lft forever" instead of veth... address